### PR TITLE
Add unit tests for UI components

### DIFF
--- a/src/components/GameEngine/__tests__/VexFlowNoteDisplay.test.tsx
+++ b/src/components/GameEngine/__tests__/VexFlowNoteDisplay.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import VexFlowNoteDisplay from '../VexFlowNoteDisplay';
+import { Note } from '../../../types/game';
+
+// Mock vexflow to avoid depending on actual implementation
+jest.mock('vexflow', () => {
+  class MockRenderer {
+    static Backends = { SVG: 'svg' };
+    constructor(element: any) {
+      this.element = element;
+      this.element.innerHTML = '<svg></svg>';
+    }
+    resize() {}
+    getContext() { return { setFont() {} }; }
+  }
+  class MockStave {
+    addClef() { return this; }
+    setContext() { return { draw() {} }; }
+  }
+  class MockStaveNote {}
+  class MockVoice { addTickables() {} draw() {} }
+  class MockFormatter { joinVoices() { return this; } format() {} }
+  return { Renderer: MockRenderer, Stave: MockStave, StaveNote: MockStaveNote, Voice: MockVoice, Formatter: MockFormatter };
+});
+
+describe('VexFlowNoteDisplay', () => {
+  test('renders SVG when a note is provided', () => {
+    const note: Note = { pitch: 'C4', staffPosition: 0 };
+    const { container } = render(<VexFlowNoteDisplay note={note} showHint={false} />);
+    // the mock renderer injects an svg element
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/components/UI/__tests__/LevelSelect.test.tsx
+++ b/src/components/UI/__tests__/LevelSelect.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, within } from '@testing-library/react';
+import LevelSelect from '../LevelSelect';
+import { LevelProgress } from '../../../types/game';
+
+describe('LevelSelect', () => {
+  const baseProgress: LevelProgress[] = [
+    { levelNumber: 1, oinks: 0, bestScore: 0, completed: false },
+    { levelNumber: 2, oinks: 0, bestScore: 0, completed: false },
+    { levelNumber: 3, oinks: 0, bestScore: 0, completed: false },
+    { levelNumber: 4, oinks: 0, bestScore: 0, completed: false }
+  ];
+
+  test('disables locked level button', () => {
+    render(
+      <LevelSelect levelProgress={baseProgress} onSelectLevel={() => {}} onBack={() => {}} />
+    );
+    const level2Heading = screen.getByText('Level 2');
+    const card = level2Heading.closest('.level-card') as HTMLElement;
+    const button = within(card).getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('🔒 Locked');
+  });
+
+  test('enables unlocked level button when previous level has oinks', () => {
+    const progress = JSON.parse(JSON.stringify(baseProgress)) as LevelProgress[];
+    progress[0].oinks = 1; // unlock level 2
+    render(
+      <LevelSelect levelProgress={progress} onSelectLevel={() => {}} onBack={() => {}} />
+    );
+    const level2Heading = screen.getByText('Level 2');
+    const card = level2Heading.closest('.level-card') as HTMLElement;
+    const button = within(card).getByRole('button');
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveTextContent('Play! 🎹');
+  });
+});

--- a/src/components/UI/__tests__/ProgressBar.test.tsx
+++ b/src/components/UI/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import ProgressBar from '../ProgressBar';
+
+describe('ProgressBar', () => {
+  test('displays correct width and pig icon when progress >= 10%', () => {
+    render(<ProgressBar current={1} total={10} />);
+    const fill = document.querySelector('.progress-fill') as HTMLElement;
+    expect(fill.style.width).toBe('10%');
+    expect(screen.getByText('🐷')).toBeInTheDocument();
+  });
+
+  test('hides pig icon when progress is 0%', () => {
+    render(<ProgressBar current={0} total={10} />);
+    const fill = document.querySelector('.progress-fill') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+    expect(screen.queryByText('🐷')).toBeNull();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add `setupTests.ts` to configure jest-dom
- create ProgressBar tests
- create LevelSelect tests
- create VexFlowNoteDisplay tests with mocked vexflow

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683d25a2a3fc8327ae56cdfbe1c4b9e5