### PR TITLE
Replace points with oinks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ const App: React.FC = () => {
   const [gameState, setGameState] = useState<GameState>({
     currentLevel: 0,
     currentNote: null,
-    score: 0,
     strikes: 0,
     pigCoins: 0,
     unlockedItems: [],
@@ -28,10 +27,10 @@ const App: React.FC = () => {
   });
 
   const [levelProgress, setLevelProgress] = useState<LevelProgress[]>([
-    { levelNumber: 1, oinks: 0, bestScore: 0, completed: false },
-    { levelNumber: 2, oinks: 0, bestScore: 0, completed: false },
-    { levelNumber: 3, oinks: 0, bestScore: 0, completed: false },
-    { levelNumber: 4, oinks: 0, bestScore: 0, completed: false }
+    { levelNumber: 1, oinks: 0, completed: false },
+    { levelNumber: 2, oinks: 0, completed: false },
+    { levelNumber: 3, oinks: 0, completed: false },
+    { levelNumber: 4, oinks: 0, completed: false }
   ]);
 
   const [currentScreen, setCurrentScreen] = useState<'menu' | 'game' | 'levelSelect'>('menu');
@@ -64,7 +63,6 @@ const App: React.FC = () => {
     setGameState(prev => ({
       ...prev,
       currentLevel: level,
-      score: 0,
       strikes: 0,
       streak: 0,
       notesCompleted: 0
@@ -72,7 +70,7 @@ const App: React.FC = () => {
     setCurrentScreen('game');
   };
 
-  const handleLevelComplete = (oinks: number, score: number) => {
+  const handleLevelComplete = (oinks: number) => {
     const updatedProgress = [...levelProgress];
     const levelIndex = gameState.currentLevel - 1;
     
@@ -80,7 +78,6 @@ const App: React.FC = () => {
       updatedProgress[levelIndex] = {
         ...updatedProgress[levelIndex],
         oinks: Math.max(oinks, updatedProgress[levelIndex].oinks),
-        bestScore: Math.max(score, updatedProgress[levelIndex].bestScore),
         completed: true
       };
       

--- a/src/components/GameEngine/GameController.css
+++ b/src/components/GameEngine/GameController.css
@@ -37,16 +37,21 @@
   font-weight: bold;
 }
 
-.score {
-  color: #FF69B4;
-}
-
 .coins {
   color: #FFD700;
 }
 
-.streak {
+.super-oink {
   color: #FF6347;
+}
+
+.oinks {
+  display: flex;
+  gap: 5px;
+}
+
+.oink-icon.empty {
+  filter: grayscale(100%) opacity(0.3);
 }
 
 .game-main {

--- a/src/components/GameEngine/GameController.tsx
+++ b/src/components/GameEngine/GameController.tsx
@@ -10,7 +10,7 @@ import './GameController.css';
 interface GameControllerProps {
   gameState: GameState;
   setGameState: React.Dispatch<React.SetStateAction<GameState>>;
-  onLevelComplete: (oinks: number, score: number) => void;
+  onLevelComplete: (oinks: number) => void;
   onBackToMenu: () => void;
 }
 
@@ -51,22 +51,16 @@ const GameController: React.FC<GameControllerProps> = ({
   const handleNoteSelect = (selectedNote: string) => {
     if (!gameState.currentNote) return;
 
-    const responseTime = Date.now() - startTime;
     const isCorrect = selectedNote === gameState.currentNote.pitch;
 
     if (isCorrect) {
-      const speedBonus = Math.max(0, 1000 - responseTime / 10);
-      const streakBonus = gameState.streak * 50;
-      const points = 100 + speedBonus + streakBonus;
-
       setPigMood('happy');
       setTimeout(() => setPigMood('idle'), 1500);
-      
+
       AudioManager.playSuccessSound();
 
       setGameState(prev => ({
         ...prev,
-        score: prev.score + points,
         streak: prev.streak + 1,
         strikes: 0,
         pigCoins: prev.pigCoins + 10,
@@ -99,7 +93,7 @@ const GameController: React.FC<GameControllerProps> = ({
       setPigMood('celebrating');
       AudioManager.playLevelCompleteSound();
       setTimeout(() => {
-        onLevelComplete(oinks, gameState.score);
+        onLevelComplete(oinks);
       }, 2000);
     }
   }, [gameState.notesCompleted, gameState.notesInLevel]);
@@ -111,6 +105,11 @@ const GameController: React.FC<GameControllerProps> = ({
     return 1;
   };
 
+  const renderOinks = (count: number) =>
+    Array.from({ length: 3 }, (_, i) => (
+      <span key={i} className={`oink-icon ${i < count ? 'earned' : 'empty'}`}>🐽</span>
+    ));
+
   return (
     <div className="game-controller">
       <div className="game-header">
@@ -118,9 +117,9 @@ const GameController: React.FC<GameControllerProps> = ({
           ← Back
         </button>
         <div className="game-stats">
-          <div className="score">Score: {gameState.score}</div>
+          <div className="oinks">{renderOinks(calculateOinks())}</div>
           <div className="coins">🪙 {gameState.pigCoins}</div>
-          <div className="streak">🔥 {gameState.streak}</div>
+          <div className="super-oink">🐽 {gameState.streak}</div>
         </div>
       </div>
 

--- a/src/components/UI/LevelSelect.css
+++ b/src/components/UI/LevelSelect.css
@@ -68,11 +68,6 @@
   filter: grayscale(100%) opacity(0.3);
 }
 
-.best-score {
-  color: #FF69B4;
-  font-weight: bold;
-  margin-bottom: 20px;
-}
 
 .play-level-button {
   background: #FF69B4;

--- a/src/components/UI/LevelSelect.tsx
+++ b/src/components/UI/LevelSelect.tsx
@@ -57,10 +57,6 @@ const LevelSelect: React.FC<LevelSelectProps> = ({
                 {renderOinks(level.oinks)}
               </div>
               
-              {level.bestScore > 0 && (
-                <p className="best-score">Best Score: {level.bestScore}</p>
-              )}
-              
               <button
                 className="play-level-button"
                 onClick={() => onSelectLevel(level.levelNumber)}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -7,7 +7,6 @@ export interface Note {
 export interface GameState {
   currentLevel: number;
   currentNote: Note | null;
-  score: number;
   strikes: number;
   pigCoins: number;
   unlockedItems: CustomizationItem[];
@@ -46,7 +45,6 @@ export interface GameSettings {
 export interface LevelProgress {
   levelNumber: number;
   oinks: number;
-  bestScore: number;
   completed: boolean;
 }
 


### PR DESCRIPTION
## Summary
- track level progress only using oinks
- remove numerical score and best score tracking
- display filled oinks during gameplay
- rename streak indicator to **super oink**

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683d20afe6dc8327be90b118b33c3e15