### PR TITLE
Fix sharps display on staff

### DIFF
--- a/src/components/GameEngine/VexFlowNoteDisplay.tsx
+++ b/src/components/GameEngine/VexFlowNoteDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Renderer, Stave, StaveNote, Voice, Formatter } from 'vexflow';
+import { Renderer, Stave, StaveNote, Voice, Formatter, Accidental } from 'vexflow';
 import { Note } from '../../types/game';
 import './NoteDisplay.css';
 
@@ -49,6 +49,11 @@ const VexFlowNoteDisplay: React.FC<VexFlowNoteDisplayProps> = ({ note, showHint 
         keys: [vexNote],
         duration: 'q', // quarter note
       });
+
+      // Add accidental symbol when needed so the sharp appears on the staff
+      if (note.pitch.includes('#')) {
+        staveNote.addAccidental(0, new Accidental('#'));
+      }
 
       // Color the note if hint is shown
       if (showHint) {


### PR DESCRIPTION
## Summary
- show accidentals in `VexFlowNoteDisplay`

## Testing
- `npm test --silent -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_683d1bc18bf48327962ed0c0e80f5b95