### PR TITLE
Fix mobile stave rendering with proper VexFlow sizing

### DIFF
--- a/src/components/GameEngine/NoteDisplay.css
+++ b/src/components/GameEngine/NoteDisplay.css
@@ -23,20 +23,21 @@
 /* Mobile responsive styles */
 @media (max-width: 768px) {
   .note-display {
-    padding: 2px;
-    border-radius: 6px;
+    padding: 5px;
+    border-radius: 8px;
     margin: 0;
   }
 
   .vexflow-container {
     min-height: 90px;
-    transform: scale(0.75);
-    transform-origin: center;
-    margin: -25px 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: visible;
   }
 
   .hint-text {
-    margin-top: -10px;
+    margin-top: 5px;
     font-size: 0.85rem;
   }
 }

--- a/src/components/GameEngine/VexFlowNoteDisplay.tsx
+++ b/src/components/GameEngine/VexFlowNoteDisplay.tsx
@@ -19,9 +19,17 @@ const VexFlowNoteDisplay: React.FC<VexFlowNoteDisplayProps> = ({ note, showHint,
     // Clear previous render
     containerRef.current.innerHTML = '';
 
+    // Responsive sizing based on screen width
+    const isMobile = window.innerWidth <= 768;
+    const width = isMobile ? 320 : 500;
+    const height = isMobile ? 120 : 250;
+    const staveWidth = isMobile ? 240 : 400;
+    const staveX = isMobile ? 40 : 10;
+    const staveY = isMobile ? 0 : 60;
+
     // Create renderer
     const renderer = new Renderer(containerRef.current, Renderer.Backends.SVG);
-    renderer.resize(500, 250);
+    renderer.resize(width, height);
     rendererRef.current = renderer;
 
     const context = renderer.getContext();
@@ -29,7 +37,7 @@ const VexFlowNoteDisplay: React.FC<VexFlowNoteDisplayProps> = ({ note, showHint,
 
     // Create a stave (staff)
     // Adjust vertical position to ensure enough space for ledger lines
-    const stave = new Stave(10, 60, 400);
+    const stave = new Stave(staveX, staveY, staveWidth);
     stave.addClef(clef);
     stave.setContext(context).draw();
 
@@ -63,7 +71,8 @@ const VexFlowNoteDisplay: React.FC<VexFlowNoteDisplayProps> = ({ note, showHint,
       voice.addTickables([staveNote]);
 
       // Format and draw
-      new Formatter().joinVoices([voice]).format([voice], 350);
+      const formatterWidth = isMobile ? 200 : 350;
+      new Formatter().joinVoices([voice]).format([voice], formatterWidth);
       voice.draw(context, stave);
     }
   }, [note, showHint, clef]);


### PR DESCRIPTION
## Summary
- Fixed stave rendering issues on mobile where it was cut off and not properly centered
- Implemented responsive VexFlow renderer sizing instead of CSS scaling

## Problem
The stave (musical staff) was being cut off on mobile devices and wasn't properly centered within the white container box. This was due to:
1. Fixed SVG dimensions that were too large for mobile
2. Incorrect vertical positioning that added extra padding
3. CSS transform scaling that distorted the rendering

## Solution
- Made VexFlow renderer responsive by detecting mobile screens
- Set appropriate mobile dimensions: 320x120px canvas (vs 500x250px desktop)
- Positioned stave at Y=0 to leverage VexFlow's built-in spacing
- Removed CSS transform scaling for cleaner rendering
- Maintained minimal 5px padding around the white box

## Technical Details
The key insight was that VexFlow has internal padding around the stave. Setting `staveY: 0` allows VexFlow to use its natural spacing, which combined with CSS flexbox centering creates proper vertical alignment without manual offset calculations.

## Test Plan
- [x] Tested on 375x667px viewport (iPhone SE size)
- [x] Verified stave is fully visible and not cut off
- [x] Confirmed proper horizontal and vertical centering
- [x] Validated note rendering works correctly
- [x] Checked that desktop layout remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)