### PR TITLE
Fix streak logic bugs in GameController

### DIFF
--- a/src/components/GameEngine/GameController.tsx
+++ b/src/components/GameEngine/GameController.tsx
@@ -76,15 +76,20 @@ const GameController: React.FC<GameControllerProps> = ({
       
       AudioManager.playErrorSound();
 
-      setGameState(prev => ({
-        ...prev,
-        strikes: prev.strikes + 1,
-        streak: 0
-      }));
-
-      if (gameState.strikes === 0 && gameState.settings.showHints) {
-        setShowHint(true);
-      }
+      setGameState(prev => {
+        const newStrikes = prev.strikes + 1;
+        
+        // Show hint if this is the first wrong answer and hints are enabled
+        if (prev.strikes === 0 && gameState.settings.showHints) {
+          setShowHint(true);
+        }
+        
+        return {
+          ...prev,
+          strikes: newStrikes,
+          streak: 0
+        };
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- Fixed state race condition where strikes increment and streak reset happened in same update but hint logic used stale strikes value
- Moved hint display logic inside setState callback to use correct previous strikes value (prev.strikes === 0)
- Ensures hints show on first wrong answer as intended

## Test plan
- [x] All existing tests pass
- [x] GameController test suite verifies hint behavior works correctly
- [x] No regressions in other components

Fixes #25

🤖 Generated with [Claude Code](https://claude.ai/code)