### PR TITLE
Remove coin system from the game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ const App: React.FC = () => {
     currentLevel: 0,
     currentNote: null,
     strikes: 0,
-    pigCoins: 0,
     unlockedItems: [],
     achievements: [],
     settings: initialSettings,
@@ -44,7 +43,6 @@ const App: React.FC = () => {
       setLevelProgress(prev => data.progress || prev);
       setGameState(prev => ({
         ...prev,
-        pigCoins: data.pigCoins || 0,
         unlockedItems: data.inventory || [],
         settings: data.settings || initialSettings
       }));
@@ -54,7 +52,6 @@ const App: React.FC = () => {
   const saveProgress = () => {
     const saveData = {
       progress: levelProgress,
-      pigCoins: gameState.pigCoins,
       inventory: gameState.unlockedItems,
       settings: gameState.settings
     };

--- a/src/components/GameEngine/GameController.css
+++ b/src/components/GameEngine/GameController.css
@@ -37,9 +37,6 @@
   font-weight: bold;
 }
 
-.coins {
-  color: #FFD700;
-}
 
 .super-oink {
   color: #FF6347;

--- a/src/components/GameEngine/GameController.tsx
+++ b/src/components/GameEngine/GameController.tsx
@@ -64,7 +64,6 @@ const GameController: React.FC<GameControllerProps> = ({
         ...prev,
         streak: prev.streak + 1,
         strikes: 0,
-        pigCoins: prev.pigCoins + 10,
         notesCompleted: prev.notesCompleted + 1,
         currentNote: null
       }));
@@ -119,7 +118,6 @@ const GameController: React.FC<GameControllerProps> = ({
         </button>
         <div className="game-stats">
           <div className="oinks">{renderOinks(calculateOinks())}</div>
-          <div className="coins">🪙 {gameState.pigCoins}</div>
           <div className="super-oink">🐽 {gameState.streak}</div>
         </div>
       </div>

--- a/src/components/GameEngine/__tests__/GameController.test.tsx
+++ b/src/components/GameEngine/__tests__/GameController.test.tsx
@@ -30,7 +30,6 @@ describe('GameController', () => {
     currentLevel: 1,
     currentNote: null,
     strikes: 0,
-    pigCoins: 0,
     unlockedItems: [],
     achievements: [],
     settings: {
@@ -203,8 +202,7 @@ describe('GameController', () => {
       />
     );
 
-    // Check for coins and streak display
-    expect(getByText('🪙 0')).toBeInTheDocument();
+    // Check for streak display
     expect(getByText('🐽 0')).toBeInTheDocument();
   });
 

--- a/src/components/GameEngine/__tests__/__snapshots__/GameController.test.tsx.snap
+++ b/src/components/GameEngine/__tests__/__snapshots__/GameController.test.tsx.snap
@@ -35,12 +35,6 @@ exports[`GameController renders correctly with initial state 1`] = `
         </span>
       </div>
       <div
-        class="coins"
-      >
-        🪙 
-        0
-      </div>
-      <div
         class="super-oink"
       >
         🐽 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -11,7 +11,6 @@ export interface GameState {
   currentLevel: number;
   currentNote: Note | null;
   strikes: number;
-  pigCoins: number;
   unlockedItems: CustomizationItem[];
   achievements: Achievement[];
   settings: GameSettings;
@@ -25,7 +24,6 @@ export interface CustomizationItem {
   id: string;
   type: 'hat' | 'accessory' | 'background' | 'instrument';
   name: string;
-  cost: number;
   unlocked: boolean;
   equipped: boolean;
 }


### PR DESCRIPTION
## Summary
- Removed the coin system while keeping the oinks (performance rating) and streak displays
- The coin system was partially implemented but never used for purchasing items

## Changes
- Removed `pigCoins` from GameState type definition
- Removed coin reward logic (+10 coins per correct answer) from GameController
- Removed coin display from UI (🪙 counter)
- Removed coin persistence in localStorage
- Removed `.coins` CSS styling
- Updated tests to remove coin expectations
- Removed `cost` field from CustomizationItem type

## Test plan
- [x] Start the development server
- [x] Play through a level
- [x] Verify only oinks (🐽🐽🐽) and streak (🐽 0) displays remain
- [x] Verify no coin counter is shown
- [x] Run tests to ensure they pass

🤖 Generated with [Claude Code](https://claude.ai/code)